### PR TITLE
Ensure transparent background for SwiftUI snapshots

### DIFF
--- a/Sources/SnapshotTesting/Snapshotting/SwiftUIView.swift
+++ b/Sources/SnapshotTesting/Snapshotting/SwiftUIView.swift
@@ -67,12 +67,11 @@
           let controller: UIViewController
 
           if config.size != nil {
-            controller = UIHostingController.init(
+            controller = TransparentHostingController.init(
               rootView: view
             )
           } else {
-            let hostingController = UIHostingController.init(rootView: view)
-            hostingController.view.backgroundColor = .clear
+            let hostingController = TransparentHostingController.init(rootView: view)
             let maxSize = CGSize(width: 0.0, height: 0.0)
             config.size = hostingController.sizeThatFits(in: maxSize)
 

--- a/Sources/SnapshotTesting/Snapshotting/TransparentHostingController.swift
+++ b/Sources/SnapshotTesting/Snapshotting/TransparentHostingController.swift
@@ -1,0 +1,15 @@
+import SwiftUI
+
+/// A UIHostingController subclass that sets its view's background to transparent.
+@available(iOS 13.0, tvOS 13.0, *)
+final class TransparentHostingController<Content: View>: UIHostingController<Content> {
+  override init(rootView: Content) {
+    super.init(rootView: rootView)
+    view.backgroundColor = .clear
+    view.isOpaque = false
+  }
+
+  @objc required dynamic init?(coder aDecoder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+}


### PR DESCRIPTION
## Summary
- add `TransparentHostingController` subclass to always use a clear background
- use the new controller when snapshotting SwiftUI views

## Testing
- `swift test` *(fails: unable to clone dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6876b74d0004832aa8e35fe533b7e918